### PR TITLE
修复download页面GIthub按钮国际化内容显示问题

### DIFF
--- a/src/components/DownloadPage.vue
+++ b/src/components/DownloadPage.vue
@@ -30,7 +30,7 @@ const openGithub = () => {
           </div>
         <h1 style="font-size: 3rem; margin-bottom: 20px;">{{ t('message.downloadTitle') }}</h1>
         <p style="font-size: 1.2rem; max-width: 800px; margin: 0 auto 30px;">{{ t('message.downloadDesc') }}</p>
-        <NButton type="primary" size="large" style="margin-right: 12px;" @click="openGithub">{{ t('message.github_upper_case  ') }}</NButton>
+        <NButton type="primary" size="large" style="margin-right: 12px;" @click="openGithub">{{ t('message.github_upper_case') }}</NButton>
         <p style="font-size: 1rem;">{{ t('message.downloadNotice') }}</p>
       </div>
 


### PR DESCRIPTION
问题总体长这样
<img width="1903" height="802" alt="image" src="https://github.com/user-attachments/assets/fe3da825-6525-42f5-a7d9-345a69d4f1cb" />
